### PR TITLE
Update emacs-plus@30.rb

### DIFF
--- a/Formula/emacs-plus@30.rb
+++ b/Formula/emacs-plus@30.rb
@@ -217,7 +217,7 @@ class EmacsPlusAT30 < EmacsBase
 
       # (prefix/"share/emacs/#{version}").install "lisp"
       prefix.install "nextstep/Emacs.app"
-      (prefix/"Emacs.app/Contents").install "native-lisp" if build.with? "native-comp"
+      # (prefix/"Emacs.app/Contents").install "native-lisp" if build.with? "native-comp"
 
       # inject PATH to Info.plist
       inject_path


### PR DESCRIPTION
If native-lisp is already handled by `ln -sf`, you don't need to install it, and it will result in an incorrect directory structure. That is, there will be a native-lisp directory within the native-lisp directory.